### PR TITLE
[feat] 채팅방 목록으로 실시간 메시지 전송

### DIFF
--- a/chatting-service/src/main/java/com/yapp/crew/consumer/ChattingConsumer.java
+++ b/chatting-service/src/main/java/com/yapp/crew/consumer/ChattingConsumer.java
@@ -10,7 +10,6 @@ import com.yapp.crew.domain.model.User;
 import com.yapp.crew.domain.repository.ChatRoomRepository;
 import com.yapp.crew.domain.repository.MessageRepository;
 import com.yapp.crew.domain.repository.UserRepository;
-import com.yapp.crew.domain.type.RealTimeUpdateType;
 import com.yapp.crew.domain.type.ResponseType;
 import com.yapp.crew.payload.MessageRequestPayload;
 import com.yapp.crew.payload.MessageResponsePayload;
@@ -76,6 +75,13 @@ public class ChattingConsumer {
 
 		MessageResponsePayload payload = MessageResponsePayload.buildChatMessageResponsePayload(message);
 		simpMessagingTemplate.convertAndSend("/sub/chat/room/" + message.getChatRoom().getId().toString(), payload);
+
+		if (sender.getId().equals(chatRoom.getGuest().getId())) {
+			simpMessagingTemplate.convertAndSend("/sub/user/" + chatRoom.getHost().getId().toString() + "/chat/room/", payload);
+		}
+		else {
+			simpMessagingTemplate.convertAndSend("/sub/user/" + chatRoom.getGuest().getId().toString() + "/chat/room/", payload);
+		}
 
 		String messageJson = objectMapper.writeValueAsString(message);
 		log.info("Successfully consumed message: {}", messageJson);

--- a/chatting-service/src/main/java/com/yapp/crew/payload/MessageResponsePayload.java
+++ b/chatting-service/src/main/java/com/yapp/crew/payload/MessageResponsePayload.java
@@ -34,6 +34,8 @@ public class MessageResponsePayload {
 
 	private Boolean isGuestRead;
 
+	private Long chatRoomId;
+
 	private Long senderId;
 
 	private String senderNickname;
@@ -60,6 +62,7 @@ public class MessageResponsePayload {
 				.realTimeUpdateType(RealTimeUpdateType.MESSAGE_READ)
 				.isHostRead(message.isHostRead())
 				.isGuestRead(message.isGuestRead())
+				.chatRoomId(message.getChatRoom().getId())
 				.senderId(message.getSender().getId())
 				.senderNickname(message.getSender().getNickname())
 				.createdAt(message.getCreatedAt())


### PR DESCRIPTION
- 전송자(sender) 가 게스트면 호스트의 채팅목록으로 전송, 호스트면 그 반대
- message response payload 에 chatroomid 추가 해서 어떤 채팅방을 실시간 업데이트 할지 알기 위해 필드 추가