### PR TITLE
feat: batch update 적용

### DIFF
--- a/chat-bot-service/src/main/java/com/yapp/crew/consumer/ChatBotConsumer.java
+++ b/chat-bot-service/src/main/java/com/yapp/crew/consumer/ChatBotConsumer.java
@@ -231,9 +231,6 @@ public class ChatBotConsumer {
 						e.printStackTrace();
 					}
 				});
-
-		board.finishBoard();
-		boardRepository.save(board);
 	}
 
 	@KafkaListener(topics = "${kafka.topics.board-canceled}", groupId = "${kafka.groups.board-canceled-group}")

--- a/common-module/build.gradle
+++ b/common-module/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'javax.validation:validation-api:2.0.1.Final'
     implementation 'org.apache.commons:commons-lang3:3.0'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
 
     compile 'mysql:mysql-connector-java'
 

--- a/watcher-service/build.gradle
+++ b/watcher-service/build.gradle
@@ -26,12 +26,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
     compile 'mysql:mysql-connector-java'
 
+    testImplementation 'org.springframework.boot:spring-batch-test '
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }

--- a/watcher-service/src/main/java/com/yapp/crew/WatcherServiceApplication.java
+++ b/watcher-service/src/main/java/com/yapp/crew/WatcherServiceApplication.java
@@ -2,12 +2,14 @@ package com.yapp.crew;
 
 import java.util.TimeZone;
 import javax.annotation.PostConstruct;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableBatchProcessing
 public class WatcherServiceApplication {
 
 	@PostConstruct

--- a/watcher-service/src/main/java/com/yapp/crew/service/BoardBatchService.java
+++ b/watcher-service/src/main/java/com/yapp/crew/service/BoardBatchService.java
@@ -1,0 +1,31 @@
+package com.yapp.crew.service;
+
+import com.yapp.crew.domain.model.Board;
+import com.yapp.crew.domain.repository.BoardRepository;
+import java.util.List;
+import javax.persistence.EntityManager;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class BoardBatchService {
+
+	private BoardRepository boardRepository;
+	private EntityManager entityManager;
+
+	@Autowired
+	public BoardBatchService(BoardRepository boardRepository, EntityManager entityManager) {
+		this.boardRepository = boardRepository;
+		this.entityManager = entityManager;
+	}
+
+	void updateBoardFinishedAll(List<Board> boardList) {
+		boardList.forEach(Board::finishBoard);
+		entityManager.flush();
+	}
+}

--- a/watcher-service/src/main/java/com/yapp/crew/service/WatcherService.java
+++ b/watcher-service/src/main/java/com/yapp/crew/service/WatcherService.java
@@ -19,13 +19,17 @@ public class WatcherService {
 
 	private final BoardRepository boardRepository;
 
+	private final BoardBatchService boardBatchService;
+
 	@Autowired
 	public WatcherService(
 			WatcherProducer watcherProducer,
-			BoardRepository boardRepository
+			BoardRepository boardRepository,
+			BoardBatchService boardBatchService
 	) {
 		this.watcherProducer = watcherProducer;
 		this.boardRepository = boardRepository;
+		this.boardBatchService = boardBatchService;
 	}
 
 	@Scheduled(cron = "0 0 0 * * *")
@@ -34,9 +38,9 @@ public class WatcherService {
 
 		if (!boards.isEmpty()) {
 			boards.stream()
-				.filter(board -> !board.getStatus().equals(BoardStatus.CANCELED) && !board.getStatus().equals(BoardStatus.FINISHED))
-				.forEach(board -> {
-					try {
+					.filter(board -> !board.getStatus().equals(BoardStatus.CANCELED) && !board.getStatus().equals(BoardStatus.FINISHED))
+					.forEach(board -> {
+						try {
 							BoardFinishedPayload payload = BoardFinishedPayload.builder()
 									.boardId(board.getId())
 									.build();
@@ -47,6 +51,8 @@ public class WatcherService {
 							ex.printStackTrace();
 						}
 					});
+
+			boardBatchService.updateBoardFinishedAll(boards);
 		}
 	}
 }

--- a/watcher-service/src/main/resources/application-dev.yml
+++ b/watcher-service/src/main/resources/application-dev.yml
@@ -30,7 +30,7 @@ spring:
         bootstrap.servers: 172.31.18.97:9092
 
   datasource:
-    url: jdbc:mysql://172.31.18.97:3306/explanet_dev?allowPublicKeyRetrieval=true&useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&createDatabaseIfNotExist=true
+    url: jdbc:mysql://172.31.18.97:3306/explanet_dev?rewriteBatchedStatements=true&allowPublicKeyRetrieval=true&useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&createDatabaseIfNotExist=true
     username: alex
     password: dnjscksdn98@
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -45,6 +45,8 @@ spring:
     database-platform: org.hibernate.dialect.MySQL5Dialect
     hibernate:
       ddl-auto: create
+      jdbc:
+        batch_size: 100
 
 kafka:
   topics:

--- a/watcher-service/src/main/resources/application.yml
+++ b/watcher-service/src/main/resources/application.yml
@@ -34,7 +34,7 @@ spring:
         bootstrap.servers: localhost:9092
 
   datasource:
-    url: jdbc:mysql://localhost:3306/explanet_local?allowPublicKeyRetrieval=true&useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&createDatabaseIfNotExist=true
+    url: jdbc:mysql://localhost:3306/explanet_local?rewriteBatchedStatements=true&allowPublicKeyRetrieval=true&useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&createDatabaseIfNotExist=true
     username: root
     password: dnjscksdn98@
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -51,6 +51,8 @@ spring:
       hibernate:
         generate_statistics: true
         format_sql: true
+        jdbc:
+          batch_size: 100
     database-platform: org.hibernate.dialect.MySQL5Dialect
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
## 변경 사항
* 챗봇 서비스 컨슈머에 있던 board finish update문을 watcher service에서 하도록
* mysql db에 rewriteBatchedStatements=true

## 그냥 알게된 점 공유...?
* 공식문서에서 id가 identity일 경우에는 insert batch를 지원하지 않음 [Hibernate disables insert batching at the JDBC level transparently if you use an identity identifier generator.](https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#batch-session-batch-insert)
* update batch의 경우 3개 이하는 배치처리 하지 않고 하나씩 update하는 쿼리 문이 생성된다. 즉, 4개부터 배치처리함
* mysql에서 생성된 쿼리를 확인하고 싶으면 `logger=Slf4JLogger&maxQuerySizeToLog=999999` 옵션을 준다.
-> 하이버네이트는 배치설정여부와 관계없이 무조건 쿼리를 엔티티마다 한건씩 출력하고, 실제로 쿼리를 하나로 합치는 것은 MySQL 드라이버 차원에서 이뤄지기 때매 보고 싶으면 저 옵션을 추가해서 봐야해요