### PR TITLE
[feat] exit chat room api

### DIFF
--- a/chat-bot-service/src/main/java/com/yapp/crew/config/KafkaTopicConfig.java
+++ b/chat-bot-service/src/main/java/com/yapp/crew/config/KafkaTopicConfig.java
@@ -26,6 +26,9 @@ public class KafkaTopicConfig {
 	@Value(value = "${kafka.topics.board-finished}")
 	private String boardFinishedTopic;
 
+	@Value(value = "${kafka.topics.user-exited}")
+	private String userExitedTopic;
+
 	@Bean
 	public NewTopic guidelineMessage() {
 		return TopicBuilder
@@ -66,6 +69,15 @@ public class KafkaTopicConfig {
 	public NewTopic boardFinished() {
 		return TopicBuilder
 				.name(boardFinishedTopic)
+				.partitions(1)
+				.replicas(1)
+				.build();
+	}
+
+	@Bean
+	public NewTopic userExited() {
+		return TopicBuilder
+				.name(userExitedTopic)
 				.partitions(1)
 				.replicas(1)
 				.build();

--- a/chat-bot-service/src/main/java/com/yapp/crew/consumer/ChatBotConsumer.java
+++ b/chat-bot-service/src/main/java/com/yapp/crew/consumer/ChatBotConsumer.java
@@ -273,7 +273,7 @@ public class ChatBotConsumer {
 
 	@KafkaListener(topics = "${kafka.topics.user-exited}", groupId = "${kafka.groups.user-exited-group}")
 	public void consumeUserExitedEvent(ConsumerRecord<Long, String> consumerRecord) throws JsonProcessingException {
-		log.info("[Chat Bot Event - Board Canceled] Consumer Record: {}", consumerRecord);
+		log.info("[Chat Bot Event - User Exited] Consumer Record: {}", consumerRecord);
 
 		UserExitedPayload userExitedPayload = objectMapper.readValue(consumerRecord.value(), UserExitedPayload.class);
 

--- a/chat-bot-service/src/main/java/com/yapp/crew/json/BotMessages.java
+++ b/chat-bot-service/src/main/java/com/yapp/crew/json/BotMessages.java
@@ -42,4 +42,7 @@ public class BotMessages {
 
 	@JsonProperty(value = "board_canceled")
 	private String boardCanceled;
+
+	@JsonProperty(value = "user_exited")
+	private String userExited;
 }

--- a/chat-bot-service/src/main/java/com/yapp/crew/payload/UserExitedPayload.java
+++ b/chat-bot-service/src/main/java/com/yapp/crew/payload/UserExitedPayload.java
@@ -1,0 +1,19 @@
+package com.yapp.crew.payload;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserExitedPayload {
+
+	private Long chatRoomId;
+
+	private Long userId;
+}

--- a/chat-bot-service/src/main/resources/application-dev.yml
+++ b/chat-bot-service/src/main/resources/application-dev.yml
@@ -57,6 +57,7 @@ kafka:
     disapprove-user: disapprove-user
     board-finished: board-finished
     board-canceled: board-canceled
+    user-exited: user-exited
 
   groups:
     guideline-message-group: guideline-message-group
@@ -65,6 +66,7 @@ kafka:
     disapprove-user-group: disapprove-user-group
     board-finished-group: board-finished-group
     board-canceled-group: board-canceled-group
+    user-exited-group: user-exited-group
 
 jwt:
   header: Authorization

--- a/chat-bot-service/src/main/resources/application.yml
+++ b/chat-bot-service/src/main/resources/application.yml
@@ -60,6 +60,7 @@ kafka:
     disapprove-user: disapprove-user
     board-finished: board-finished
     board-canceled: board-canceled
+    user-exited: user-exited
 
   groups:
     guideline-message-group: guideline-message-group
@@ -68,6 +69,7 @@ kafka:
     disapprove-user-group: disapprove-user-group
     board-finished-group: board-finished-group
     board-canceled-group: board-canceled-group
+    user-exited-group: user-exited-group
 
 jwt:
   header: Authorization

--- a/chat-bot-service/src/main/resources/bot-messages.json
+++ b/chat-bot-service/src/main/resources/bot-messages.json
@@ -5,5 +5,6 @@
   "disapprove_message": "'%s'님이 신청승인을 취소하셨습니다. 아쉽지만 다음 기회에 만나요!",
   "profile_message": "%s \n\n👍🏻 %d\t👎🏻 %d\n\n기본소개\n\n%s",
   "board_finished": "활동이 종료되었습니다. 히스토리에서 활동을 평가해주세요!",
-  "board_canceled": "'%s'님이 활동을 취소하셨습니다. 해당활동은 진행되지 않습니다."
+  "board_canceled": "'%s'님이 활동을 취소하셨습니다. 해당활동은 진행되지 않습니다.",
+  "user_exited": "'%s'님이 채팅방을 나갔습니다."
 }

--- a/chatting-service/src/main/java/com/yapp/crew/consumer/ChattingConsumer.java
+++ b/chatting-service/src/main/java/com/yapp/crew/consumer/ChattingConsumer.java
@@ -79,6 +79,7 @@ public class ChattingConsumer {
 		);
 
 		chatRoom.addMessage(message);
+		chatRoomRepository.save(chatRoom);
 		messageRepository.save(message);
 
 		MessageResponsePayload payload = MessageResponsePayload.buildChatMessageResponsePayload(message);

--- a/chatting-service/src/main/java/com/yapp/crew/controller/ChattingController.java
+++ b/chatting-service/src/main/java/com/yapp/crew/controller/ChattingController.java
@@ -103,14 +103,14 @@ public class ChattingController {
 		return ResponseEntity.status(responseBody.getStatus()).body(responseBody);
 	}
 
-//	@DeleteMapping(path = "/v1/chat/room/{chatRoomId}")
-//	public ResponseEntity<?> deleteChatRoom(
-//			@RequestHeader(value = "userId") Long userId,
-//			@PathVariable(name = "chatRoomId") Long chatRoomId
-//	) {
-//		HttpResponseBody<?> responseBody = chattingService.deleteChatRoom(userId, chatRoomId);
-//		return ResponseEntity.status(responseBody.getStatus()).body(responseBody);
-//	}
+	@DeleteMapping(path = "/v1/chat/room/{chatRoomId}")
+	public ResponseEntity<?> deleteChatRoom(
+			@RequestHeader(value = "userId") Long userId,
+			@PathVariable(name = "chatRoomId") Long chatRoomId
+	) {
+		HttpResponseBody<?> responseBody = chattingService.deleteChatRoom(userId, chatRoomId);
+		return ResponseEntity.status(responseBody.getStatus()).body(responseBody);
+	}
 
 	@PostMapping(path = "/v1/board/{boardId}/apply")
 	public ResponseEntity<?> applyUser(

--- a/chatting-service/src/main/java/com/yapp/crew/controller/ChattingController.java
+++ b/chatting-service/src/main/java/com/yapp/crew/controller/ChattingController.java
@@ -104,7 +104,7 @@ public class ChattingController {
 	}
 
 	@DeleteMapping(path = "/v1/chat/room/{chatRoomId}")
-	public ResponseEntity<?> deleteChatRoom(
+	public ResponseEntity<?> exitChatRoom(
 			@RequestHeader(value = "userId") Long userId,
 			@PathVariable(name = "chatRoomId") Long chatRoomId
 	) {

--- a/chatting-service/src/main/java/com/yapp/crew/controller/ChattingController.java
+++ b/chatting-service/src/main/java/com/yapp/crew/controller/ChattingController.java
@@ -69,7 +69,7 @@ public class ChattingController {
 	@GetMapping(path = "/v1/chat/room/{chatRoomId}/message")
 	public ResponseEntity<?> receiveChatMessages(
 			@RequestHeader(value = "userId") Long userId,
-			@PathVariable("chatRoomId") Long chatRoomId
+			@PathVariable(name = "chatRoomId") Long chatRoomId
 	) {
 		HttpResponseBody<List<MessageResponsePayload>> responseBody = chattingService.receiveChatMessages(chatRoomId, userId);
 		return ResponseEntity.status(responseBody.getStatus()).body(responseBody);
@@ -78,8 +78,8 @@ public class ChattingController {
 	@PutMapping(path = "/v1/chat/room/{chatRoomId}/message/{messageId}")
 	public ResponseEntity<?> updateMessageIsRead(
 			@RequestHeader(value = "userId") Long userId,
-			@PathVariable("chatRoomId") Long chatRoomId,
-			@PathVariable("messageId") Long messageId
+			@PathVariable(name = "chatRoomId") Long chatRoomId,
+			@PathVariable(name = "messageId") Long messageId
 	) {
 		HttpResponseBody<?> responseBody = chattingService.updateMessageIsRead(userId, chatRoomId, messageId);
 		return ResponseEntity.status(responseBody.getStatus()).body(responseBody);
@@ -103,11 +103,20 @@ public class ChattingController {
 		return ResponseEntity.status(responseBody.getStatus()).body(responseBody);
 	}
 
+//	@DeleteMapping(path = "/v1/chat/room/{chatRoomId}")
+//	public ResponseEntity<?> deleteChatRoom(
+//			@RequestHeader(value = "userId") Long userId,
+//			@PathVariable(name = "chatRoomId") Long chatRoomId
+//	) {
+//		HttpResponseBody<?> responseBody = chattingService.deleteChatRoom(userId, chatRoomId);
+//		return ResponseEntity.status(responseBody.getStatus()).body(responseBody);
+//	}
+
 	@PostMapping(path = "/v1/board/{boardId}/apply")
 	public ResponseEntity<?> applyUser(
 			@RequestHeader(value = "userId") Long userId,
 			@Valid @RequestBody ApplyRequestPayload applyRequestPayload,
-			@PathVariable("boardId") Long boardId
+			@PathVariable(name = "boardId") Long boardId
 	) throws JsonProcessingException {
 
 		applyRequestPayload.setBoardId(boardId);
@@ -121,7 +130,7 @@ public class ChattingController {
 	public ResponseEntity<?> approveUser(
 			@RequestHeader(value = "userId") Long userId,
 			@Valid @RequestBody ApproveRequestPayload approveRequestPayload,
-			@PathVariable("boardId") Long boardId
+			@PathVariable(name = "boardId") Long boardId
 	) throws JsonProcessingException {
 
 		approveRequestPayload.setBoardId(boardId);
@@ -135,7 +144,7 @@ public class ChattingController {
 	public ResponseEntity<?> disapproveUser(
 			@RequestHeader(value = "userId") Long userId,
 			@Valid @RequestBody ApproveRequestPayload approveRequestPayload,
-			@PathVariable("boardId") Long boardId
+			@PathVariable(name = "boardId") Long boardId
 	) throws JsonProcessingException {
 
 		approveRequestPayload.setBoardId(boardId);

--- a/chatting-service/src/main/java/com/yapp/crew/controller/ChattingController.java
+++ b/chatting-service/src/main/java/com/yapp/crew/controller/ChattingController.java
@@ -109,7 +109,7 @@ public class ChattingController {
 			@PathVariable(name = "chatRoomId") Long chatRoomId
 	) throws JsonProcessingException {
 
-		HttpResponseBody<?> responseBody = chattingService.deleteChatRoom(userId, chatRoomId);
+		HttpResponseBody<?> responseBody = chattingService.exitChatRoom(userId, chatRoomId);
 		return ResponseEntity.status(responseBody.getStatus()).body(responseBody);
 	}
 

--- a/chatting-service/src/main/java/com/yapp/crew/controller/ChattingController.java
+++ b/chatting-service/src/main/java/com/yapp/crew/controller/ChattingController.java
@@ -107,7 +107,8 @@ public class ChattingController {
 	public ResponseEntity<?> exitChatRoom(
 			@RequestHeader(value = "userId") Long userId,
 			@PathVariable(name = "chatRoomId") Long chatRoomId
-	) {
+	) throws JsonProcessingException {
+
 		HttpResponseBody<?> responseBody = chattingService.deleteChatRoom(userId, chatRoomId);
 		return ResponseEntity.status(responseBody.getStatus()).body(responseBody);
 	}

--- a/chatting-service/src/main/java/com/yapp/crew/payload/ChatRoomResponsePayload.java
+++ b/chatting-service/src/main/java/com/yapp/crew/payload/ChatRoomResponsePayload.java
@@ -88,7 +88,7 @@ public class ChatRoomResponsePayload {
 				.map(chatRoom -> {
 					List<Message> messages = chatRoom.getMessages();
 
-					boolean isHost = chatRoom.isSenderChatRoomHost(userId);
+					boolean isHost = chatRoom.isUserChatRoomHost(userId);
 					Long unreadMessages = chatRoom.countUnreadMessages(isHost);
 					String opponentNickname;
 					if (isHost) {

--- a/chatting-service/src/main/java/com/yapp/crew/payload/UserExitedPayload.java
+++ b/chatting-service/src/main/java/com/yapp/crew/payload/UserExitedPayload.java
@@ -1,0 +1,19 @@
+package com.yapp.crew.payload;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserExitedPayload {
+
+	private Long chatRoomId;
+
+	private Long userId;
+}

--- a/chatting-service/src/main/java/com/yapp/crew/producer/ChattingProducer.java
+++ b/chatting-service/src/main/java/com/yapp/crew/producer/ChattingProducer.java
@@ -212,7 +212,7 @@ public class ChattingProducer {
 				MessageResponsePayload userExitedRealtimeUpdatePayload = MessageResponsePayload.buildRealTimeUpdateResponsePayload(RealTimeUpdateType.USER_EXITED);
 
 				simpMessagingTemplate.convertAndSend(
-						"/sub/chat/room/" + userExitedPayload.getChatRoomId().toString(),
+						"/sub/user/" + userExitedPayload.getUserId().toString() + "/chat/room",
 						userExitedRealtimeUpdatePayload
 				);
 			}

--- a/chatting-service/src/main/java/com/yapp/crew/producer/ChattingProducer.java
+++ b/chatting-service/src/main/java/com/yapp/crew/producer/ChattingProducer.java
@@ -8,6 +8,7 @@ import com.yapp.crew.payload.ApproveRequestPayload;
 import com.yapp.crew.payload.GuidelineRequestPayload;
 import com.yapp.crew.payload.MessageRequestPayload;
 import com.yapp.crew.payload.MessageResponsePayload;
+import com.yapp.crew.payload.UserExitedPayload;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -43,6 +44,9 @@ public class ChattingProducer {
 
 	@Value(value = "${kafka.topics.disapprove-user}")
 	private String disapproveUserTopic;
+
+	@Value(value = "${kafka.topics.user-exited}")
+	private String userExitedTopic;
 
 	private final SimpMessagingTemplate simpMessagingTemplate;
 
@@ -182,6 +186,34 @@ public class ChattingProducer {
 				simpMessagingTemplate.convertAndSend(
 						"/sub/chat/room/" + approveRequestPayload.getChatRoomId().toString(),
 						disapproveRealtimeUpdatePayload
+				);
+			}
+		});
+		return listenableFuture;
+	}
+
+	public ListenableFuture<SendResult<Long, String>> sendUserExitMessage(UserExitedPayload userExitedPayload) throws JsonProcessingException {
+		Long key = userExitedPayload.getChatRoomId();
+		String value = objectMapper.writeValueAsString(userExitedPayload);
+
+		ProducerRecord<Long, String> producerRecord = buildProducerRecord(key, value, userExitedTopic);
+		ListenableFuture<SendResult<Long, String>> listenableFuture = kafkaTemplate.send(producerRecord);
+
+		listenableFuture.addCallback(new ListenableFutureCallback<>() {
+			@Override
+			public void onFailure(Throwable ex) {
+				handleFailure(key, value, ex);
+			}
+
+			@Override
+			public void onSuccess(SendResult<Long, String> result) {
+				handleSuccess(key, value, result);
+
+				MessageResponsePayload userExitedRealtimeUpdatePayload = MessageResponsePayload.buildRealTimeUpdateResponsePayload(RealTimeUpdateType.USER_EXITED);
+
+				simpMessagingTemplate.convertAndSend(
+						"/sub/chat/room/" + userExitedPayload.getChatRoomId().toString(),
+						userExitedRealtimeUpdatePayload
 				);
 			}
 		});

--- a/chatting-service/src/main/java/com/yapp/crew/service/ChattingService.java
+++ b/chatting-service/src/main/java/com/yapp/crew/service/ChattingService.java
@@ -33,7 +33,6 @@ import com.yapp.crew.payload.MessageResponsePayload;
 import com.yapp.crew.producer.ChattingProducer;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/chatting-service/src/main/java/com/yapp/crew/service/ChattingService.java
+++ b/chatting-service/src/main/java/com/yapp/crew/service/ChattingService.java
@@ -124,7 +124,7 @@ public class ChattingService {
 		);
 	}
 
-	public HttpResponseBody<?> deleteChatRoom(Long userId, Long chatRoomId) throws JsonProcessingException {
+	public HttpResponseBody<?> exitChatRoom(Long userId, Long chatRoomId) throws JsonProcessingException {
 		User user = userRepository.findUserById(userId)
 				.orElseThrow(() -> new UserNotFoundException("User not found"));
 

--- a/chatting-service/src/main/java/com/yapp/crew/service/ChattingService.java
+++ b/chatting-service/src/main/java/com/yapp/crew/service/ChattingService.java
@@ -122,9 +122,23 @@ public class ChattingService {
 		);
 	}
 
-//	public HttpResponseBody<?> deleteChatRoom(Long userId, Long chatRoomId) {
-//
-//	}
+	public HttpResponseBody<?> deleteChatRoom(Long userId, Long chatRoomId) {
+		User user = userRepository.findUserById(userId)
+				.orElseThrow(() -> new UserNotFoundException("User not found"));
+
+		ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+				.orElseThrow(() -> new ChatRoomNotFoundException("Chat room not found"));
+
+		boolean isHost = chatRoom.isUserChatRoomHost(userId);
+		chatRoom.exitUser(isHost);
+		chatRoomRepository.save(chatRoom);
+
+		return HttpResponseBody.buildSuccessResponse(
+				HttpStatus.OK.value(),
+				ResponseType.SUCCESS,
+				ResponseType.SUCCESS.getMessage()
+		);
+	}
 
 	public HttpResponseBody<List<ChatRoomResponsePayload>> receiveChatRooms(Long userId) {
 		List<ChatRoom> chatRooms = chatRoomRepository.findAllByUserId(userId);
@@ -142,7 +156,7 @@ public class ChattingService {
 		ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
 				.orElseThrow(() -> new ChatRoomNotFoundException("Chat room not found"));
 
-		boolean isHost = chatRoom.isSenderChatRoomHost(userId);
+		boolean isHost = chatRoom.isUserChatRoomHost(userId);
 		Long firstUnreadChatMessageId = chatRoom.findFirstUnreadChatMessage(isHost);
 
 		String boardTitle = chatRoom.getBoard().getTitle();
@@ -178,7 +192,7 @@ public class ChattingService {
 		Message message = messageRepository.findById(messageId)
 				.orElseThrow(() -> new MessageNotFoundException("Message not found"));
 
-		boolean isHost = chatRoom.isSenderChatRoomHost(userId);
+		boolean isHost = chatRoom.isUserChatRoomHost(userId);
 
 		message.readMessage(isHost);
 		messageRepository.save(message);

--- a/chatting-service/src/main/java/com/yapp/crew/service/ChattingService.java
+++ b/chatting-service/src/main/java/com/yapp/crew/service/ChattingService.java
@@ -131,6 +131,11 @@ public class ChattingService {
 
 		boolean isHost = chatRoom.isUserChatRoomHost(userId);
 		chatRoom.exitUser(isHost);
+
+		if (chatRoom.getGuestExited() && chatRoom.getHostExited()) {
+			chatRoom.inactivateChatRoom();
+		}
+
 		chatRoomRepository.save(chatRoom);
 
 		return HttpResponseBody.buildSuccessResponse(

--- a/chatting-service/src/main/java/com/yapp/crew/service/ChattingService.java
+++ b/chatting-service/src/main/java/com/yapp/crew/service/ChattingService.java
@@ -30,6 +30,7 @@ import com.yapp.crew.payload.ChatRoomRequestPayload;
 import com.yapp.crew.payload.ChatRoomResponsePayload;
 import com.yapp.crew.payload.GuidelineRequestPayload;
 import com.yapp.crew.payload.MessageResponsePayload;
+import com.yapp.crew.payload.UserExitedPayload;
 import com.yapp.crew.producer.ChattingProducer;
 import java.util.List;
 import java.util.Optional;
@@ -123,7 +124,7 @@ public class ChattingService {
 		);
 	}
 
-	public HttpResponseBody<?> deleteChatRoom(Long userId, Long chatRoomId) {
+	public HttpResponseBody<?> deleteChatRoom(Long userId, Long chatRoomId) throws JsonProcessingException {
 		User user = userRepository.findUserById(userId)
 				.orElseThrow(() -> new UserNotFoundException("User not found"));
 
@@ -138,6 +139,12 @@ public class ChattingService {
 		}
 
 		chatRoomRepository.save(chatRoom);
+
+		UserExitedPayload userExitedPayload = UserExitedPayload.builder()
+				.chatRoomId(chatRoom.getId())
+				.userId(user.getId())
+				.build();
+		chattingProducer.sendUserExitMessage(userExitedPayload);
 
 		return HttpResponseBody.buildSuccessResponse(
 				HttpStatus.OK.value(),

--- a/chatting-service/src/main/java/com/yapp/crew/service/ChattingService.java
+++ b/chatting-service/src/main/java/com/yapp/crew/service/ChattingService.java
@@ -122,6 +122,10 @@ public class ChattingService {
 		);
 	}
 
+//	public HttpResponseBody<?> deleteChatRoom(Long userId, Long chatRoomId) {
+//
+//	}
+
 	public HttpResponseBody<List<ChatRoomResponsePayload>> receiveChatRooms(Long userId) {
 		List<ChatRoom> chatRooms = chatRoomRepository.findAllByUserId(userId);
 

--- a/chatting-service/src/main/resources/application-dev.yml
+++ b/chatting-service/src/main/resources/application-dev.yml
@@ -51,6 +51,8 @@ kafka:
     guideline-message: guideline-message
     apply-user: apply-user
     approve-user: approve-user
+    disapprove-user: disapprove-user
+    user-exited: user-exited
 
   groups:
     chat-message-group: chat-message-group

--- a/chatting-service/src/main/resources/application.yml
+++ b/chatting-service/src/main/resources/application.yml
@@ -55,6 +55,7 @@ kafka:
     apply-user: apply-user
     approve-user: approve-user
     disapprove-user: disapprove-user
+    user-exited: user-exited
 
   groups:
     chat-message-group: chat-message-group

--- a/common-module/src/main/java/com/yapp/crew/domain/model/ChatRoom.java
+++ b/common-module/src/main/java/com/yapp/crew/domain/model/ChatRoom.java
@@ -79,6 +79,10 @@ public class ChatRoom extends BaseEntity {
 		setGuestExited(true);
 	}
 
+	public void inactivateChatRoom() {
+		setStatus(ChatRoomStatus.INACTIVE);
+	}
+
 	public boolean isUserChatRoomHost(Long userId) {
 		return userId.equals(getHost().getId());
 	}

--- a/common-module/src/main/java/com/yapp/crew/domain/model/ChatRoom.java
+++ b/common-module/src/main/java/com/yapp/crew/domain/model/ChatRoom.java
@@ -6,6 +6,7 @@ import com.yapp.crew.domain.status.ChatRoomStatus;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -32,7 +33,16 @@ public class ChatRoom extends BaseEntity {
 
 	@Setter(value = AccessLevel.PRIVATE)
 	@Enumerated(value = EnumType.STRING)
+	@Column(nullable = false)
 	private ChatRoomStatus status = ChatRoomStatus.ACTIVE;
+
+	@Setter(value = AccessLevel.PRIVATE)
+	@Column(name = "host_exited", nullable = false)
+	private Boolean hostExited = false;
+
+	@Setter(value = AccessLevel.PRIVATE)
+	@Column(name = "guest_exited", nullable = false)
+	private Boolean guestExited = false;
 
 	@JsonBackReference
 	@Setter(value = AccessLevel.PROTECTED)
@@ -61,7 +71,15 @@ public class ChatRoom extends BaseEntity {
 		this.messages.add(message);
 	}
 
-	public boolean isSenderChatRoomHost(Long userId) {
+	public void exitUser(boolean isHost) {
+		if (isHost) {
+			setHostExited(true);
+			return;
+		}
+		setGuestExited(true);
+	}
+
+	public boolean isUserChatRoomHost(Long userId) {
 		return userId.equals(getHost().getId());
 	}
 

--- a/common-module/src/main/java/com/yapp/crew/domain/repository/ChatRoomRepository.java
+++ b/common-module/src/main/java/com/yapp/crew/domain/repository/ChatRoomRepository.java
@@ -16,7 +16,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
 	List<ChatRoom> findAllByBoardId(Long boardId);
 
-	@Query(value = "select * from chat_room where host_id = ?1 or guest_id = ?1", nativeQuery = true)
+	@Query(value = "select * from chat_room where (host_id = ?1 or guest_id = ?1) and status = 'ACTIVE' order by updated_at desc", nativeQuery = true)
 	List<ChatRoom> findAllByUserId(Long userId);
 
 	Optional<ChatRoom> findByGuestIdAndBoardId(Long guestId, Long boardId);

--- a/common-module/src/main/java/com/yapp/crew/domain/type/RealTimeUpdateType.java
+++ b/common-module/src/main/java/com/yapp/crew/domain/type/RealTimeUpdateType.java
@@ -8,7 +8,8 @@ public enum RealTimeUpdateType {
 	APPLIED(0, "게시글 신청"),
 	APPROVED(1, "사용자 승인"),
 	DISAPPROVED(2, "사용자 거절"),
-	MESSAGE_READ(3, "메시지 읽음");
+	MESSAGE_READ(3, "메시지 읽음"),
+	USER_EXITED(4, "채팅방 나가기");
 
 	private final int code;
 	private final String name;


### PR DESCRIPTION
## 변경사항

- chat_room 모델에 누가 나갔는지에 대한 정보를 수집하기 위해 guest_exited, host_exited (boolean) 필드 추가
- 채팅방 나가기 api 구현
  - 요청한 사용자가 호스트 혹은 게스트에 따라서 guest_exited, host_exited 를 true 로 설정
  - 만약 이제 둘다 나간 상황이라면 해당 chat_room 의 status 를 INACTIVE 로 업데이트
  - 누가 나갔는지에 대한 봇 메시지 전송
  - 실시간으로 채팅방 나간것을 프론트에서 표시하기 위해 realtime update payload 도 전송
- 채팅방 조회할 때 이제 ACTIVE 한 채팅방만 조회하고, filter() 를 사용해서 자신이 나간방인지 한번 더 체크해서 최종 list에서 제외시킴