### PR TITLE
[feat] add healthcheck

### DIFF
--- a/api-gateway/src/main/java/com/yapp/crew/controller/HealthChecker.java
+++ b/api-gateway/src/main/java/com/yapp/crew/controller/HealthChecker.java
@@ -1,0 +1,16 @@
+package com.yapp.crew.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j(topic = "Chatting Controller - Health Checker")
+@RestController
+public class HealthChecker {
+
+	@GetMapping(path = "/health-check")
+	public String healthCheck() {
+		log.info("Health check...");
+		return "healthy";
+	}
+}

--- a/base-service/src/main/java/com/yapp/crew/controller/HealthChecker.java
+++ b/base-service/src/main/java/com/yapp/crew/controller/HealthChecker.java
@@ -1,0 +1,16 @@
+package com.yapp.crew.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j(topic = "Chatting Controller - Health Checker")
+@RestController
+public class HealthChecker {
+
+	@GetMapping(path = "/health-check")
+	public String healthCheck() {
+		log.info("Health check...");
+		return "healthy";
+	}
+}

--- a/board-service/src/main/java/com/yapp/crew/controller/HealthChecker.java
+++ b/board-service/src/main/java/com/yapp/crew/controller/HealthChecker.java
@@ -1,0 +1,16 @@
+package com.yapp.crew.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j(topic = "Chatting Controller - Health Checker")
+@RestController
+public class HealthChecker {
+
+	@GetMapping(path = "/health-check")
+	public String healthCheck() {
+		log.info("Health check...");
+		return "healthy";
+	}
+}

--- a/chat-bot-service/src/main/java/com/yapp/crew/controller/HealthChecker.java
+++ b/chat-bot-service/src/main/java/com/yapp/crew/controller/HealthChecker.java
@@ -1,0 +1,16 @@
+package com.yapp.crew.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j(topic = "Chatting Controller - Health Checker")
+@RestController
+public class HealthChecker {
+
+	@GetMapping(path = "/health-check")
+	public String healthCheck() {
+		log.info("Health check...");
+		return "healthy";
+	}
+}

--- a/chatting-service/src/main/java/com/yapp/crew/controller/HealthChecker.java
+++ b/chatting-service/src/main/java/com/yapp/crew/controller/HealthChecker.java
@@ -1,0 +1,16 @@
+package com.yapp.crew.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j(topic = "Chatting Controller - Health Checker")
+@RestController
+public class HealthChecker {
+
+	@GetMapping(path = "/health-check")
+	public String healthCheck() {
+		log.info("Health check...");
+		return "healthy";
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 20s
 
   api-gateway:
     container_name: api-gateway
@@ -53,7 +52,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 20s
     depends_on:
       - mysql
 
@@ -71,7 +69,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 20s
     depends_on:
       - mysql
       - kafka
@@ -91,7 +88,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 20s
     depends_on:
       - mysql
       - kafka
@@ -111,7 +107,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 20s
     depends_on:
       - mysql
       - api-gateway
@@ -130,7 +125,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 20s
     depends_on:
       - mysql
       - kafka
@@ -150,7 +144,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 20s
     depends_on:
       - mysql
       - api-gateway
@@ -169,7 +162,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 20s
     depends_on:
       - mysql
       - api-gateway
@@ -188,7 +180,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 20s
     depends_on:
       - mysql
       - kafka

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,13 @@ services:
       - MYSQL_DATABASE=explanet_dev
       - MYSQL_USER=alex
       - MYSQL_PASSWORD=dnjscksdn98@
+      - docker exec mysql mysqladmin -ualex -pdnjscksdn98@ ping
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "52.78.52.254", "-u", "alex", "-p$$MYSQL_ROOT_PASSWORD" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
 
   api-gateway:
     container_name: api-gateway
@@ -43,7 +50,7 @@ services:
       dockerfile: Dockerfile
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://52.78.52.254/health-check" ]
-      interval: 1m30s
+      interval: 30s
       timeout: 10s
       retries: 3
       start_period: 20s
@@ -60,8 +67,8 @@ services:
         ENVIRONMENT: dev
       dockerfile: Dockerfile
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://52.78.52.254:8080/health-check"]
-      interval: 1m30s
+      test: [ "CMD", "curl", "-f", "http://52.78.52.254:8080/health-check" ]
+      interval: 30s
       timeout: 10s
       retries: 3
       start_period: 20s
@@ -81,7 +88,7 @@ services:
       dockerfile: Dockerfile
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://52.78.52.254:8081/health-check" ]
-      interval: 1m30s
+      interval: 30s
       timeout: 10s
       retries: 3
       start_period: 20s
@@ -101,7 +108,7 @@ services:
       dockerfile: Dockerfile
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://52.78.52.254:8082/health-check" ]
-      interval: 1m30s
+      interval: 30s
       timeout: 10s
       retries: 3
       start_period: 20s
@@ -120,7 +127,7 @@ services:
       dockerfile: Dockerfile
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://52.78.52.254:8083/health-check" ]
-      interval: 1m30s
+      interval: 30s
       timeout: 10s
       retries: 3
       start_period: 20s
@@ -140,7 +147,7 @@ services:
       dockerfile: Dockerfile
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://52.78.52.254:8084/health-check" ]
-      interval: 1m30s
+      interval: 30s
       timeout: 10s
       retries: 3
       start_period: 20s
@@ -159,7 +166,7 @@ services:
       dockerfile: Dockerfile
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://52.78.52.254:8085/health-check" ]
-      interval: 1m30s
+      interval: 30s
       timeout: 10s
       retries: 3
       start_period: 20s
@@ -178,7 +185,7 @@ services:
       dockerfile: Dockerfile
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://52.78.52.254:8086/health-check" ]
-      interval: 1m30s
+      interval: 30s
       timeout: 10s
       retries: 3
       start_period: 20s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,12 @@ services:
       args:
         ENVIRONMENT: dev
       dockerfile: Dockerfile
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://52.78.52.254/health-check" ]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     depends_on:
       - mysql
 
@@ -53,6 +59,12 @@ services:
       args:
         ENVIRONMENT: dev
       dockerfile: Dockerfile
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://52.78.52.254:8080/health-check"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     depends_on:
       - mysql
       - kafka
@@ -67,6 +79,12 @@ services:
       args:
         ENVIRONMENT: dev
       dockerfile: Dockerfile
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://52.78.52.254:8081/health-check" ]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     depends_on:
       - mysql
       - kafka
@@ -81,6 +99,12 @@ services:
       args:
         ENVIRONMENT: dev
       dockerfile: Dockerfile
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://52.78.52.254:8082/health-check" ]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     depends_on:
       - mysql
       - api-gateway
@@ -94,6 +118,12 @@ services:
       args:
         ENVIRONMENT: dev
       dockerfile: Dockerfile
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://52.78.52.254:8083/health-check" ]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     depends_on:
       - mysql
       - kafka
@@ -108,6 +138,12 @@ services:
       args:
         ENVIRONMENT: dev
       dockerfile: Dockerfile
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://52.78.52.254:8084/health-check" ]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     depends_on:
       - mysql
       - api-gateway
@@ -121,6 +157,12 @@ services:
       args:
         ENVIRONMENT: dev
       dockerfile: Dockerfile
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://52.78.52.254:8085/health-check" ]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     depends_on:
       - mysql
       - api-gateway
@@ -134,6 +176,12 @@ services:
       args:
         ENVIRONMENT: dev
       dockerfile: Dockerfile
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://52.78.52.254:8086/health-check" ]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     depends_on:
       - mysql
       - kafka

--- a/login-service/src/main/java/com/yapp/crew/controller/HealthChecker.java
+++ b/login-service/src/main/java/com/yapp/crew/controller/HealthChecker.java
@@ -1,0 +1,16 @@
+package com.yapp.crew.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j(topic = "Chatting Controller - Health Checker")
+@RestController
+public class HealthChecker {
+
+	@GetMapping(path = "/health-check")
+	public String healthCheck() {
+		log.info("Health check...");
+		return "healthy";
+	}
+}

--- a/mypage-service/src/main/java/com/yapp/crew/controller/HealthChecker.java
+++ b/mypage-service/src/main/java/com/yapp/crew/controller/HealthChecker.java
@@ -1,0 +1,16 @@
+package com.yapp.crew.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j(topic = "Chatting Controller - Health Checker")
+@RestController
+public class HealthChecker {
+
+	@GetMapping(path = "/health-check")
+	public String healthCheck() {
+		log.info("Health check...");
+		return "healthy";
+	}
+}

--- a/watcher-service/src/main/java/com/yapp/crew/controller/HealthChecker.java
+++ b/watcher-service/src/main/java/com/yapp/crew/controller/HealthChecker.java
@@ -1,0 +1,16 @@
+package com.yapp.crew.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j(topic = "Chatting Controller - Health Checker")
+@RestController
+public class HealthChecker {
+
+	@GetMapping(path = "/health-check")
+	public String healthCheck() {
+		log.info("Health check...");
+		return "healthy";
+	}
+}


### PR DESCRIPTION
## 변경 사항

- 각 서비스에 health-check 할 수 있는 api 추가
```
healthcheck:
      test: [ "CMD", "curl", "-f", "http://52.78.52.254:8082/health-check" ]  // 실행할 명령어
      interval: 30s  // 30초 마다 호출
      timeout: 10s  // 10초 내에 정상적으로 호출하면 성공
      retries: 3  // 실패하면 3번까지 재시도
```
- 쓰는 이유
  - 서비스가 정상적으로 실행이 되지 못하는데도 도커 컨테이너가 UP 되어 있는 경우가 있어서  
 health-check를 통해서 각 컨테이너들의 상태 확인
  - 기존 docker-compose ps 입력시 status에 UP만 출력되는데 적용하게 되면 UP(healthy) or UP(unhealthy) 까지 출력됨