### PR TITLE
feat: create custom handshake interceptor

### DIFF
--- a/chatting-service/src/main/java/com/yapp/crew/config/WebSocketConfig.java
+++ b/chatting-service/src/main/java/com/yapp/crew/config/WebSocketConfig.java
@@ -2,14 +2,7 @@ package com.yapp.crew.config;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-import org.springframework.messaging.simp.stomp.StompCommand;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
-import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -32,23 +25,5 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 		registry
 				.setApplicationDestinationPrefixes("/pub")
 				.enableSimpleBroker("/sub");
-	}
-
-	@Override
-	public void configureClientInboundChannel(ChannelRegistration registration) {
-		registration.interceptors(new ChannelInterceptor() {
-			@Override
-			public Message<?> preSend(Message<?> message, MessageChannel channel) {
-				StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-
-				if (accessor != null && StompCommand.CONNECT == accessor.getCommand()) {
-					String token = (String) accessor.getHeader("token");
-					log.info("message token -> {}", token);
-					// TODO: 값들이 잘 들어온다면 사용자 인증 추가
-				}
-
-				return message;
-			}
-		});
 	}
 }

--- a/chatting-service/src/main/java/com/yapp/crew/websocket/CustomHandshakeInterceptor.java
+++ b/chatting-service/src/main/java/com/yapp/crew/websocket/CustomHandshakeInterceptor.java
@@ -1,0 +1,43 @@
+package com.yapp.crew.websocket;
+
+import com.yapp.crew.auth.Auth;
+import com.yapp.crew.domain.repository.UserRepository;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+@Slf4j(topic = "Custom Handshake Interceptor")
+public class CustomHandshakeInterceptor implements HandshakeInterceptor {
+
+  @Value(value = "${jwt.header}")
+  private String AuthorizationHeader;
+
+  private final Auth auth;
+  private final UserRepository userRepository;
+
+  public CustomHandshakeInterceptor(Auth auth, UserRepository userRepository) {
+    this.auth = auth;
+    this.userRepository = userRepository;
+  }
+
+  @Override
+  public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+    if (request instanceof ServletServerHttpRequest) {
+      ServletServerHttpRequest servletRequest = (ServletServerHttpRequest) request;
+      String token = servletRequest.getServletRequest().getHeader(AuthorizationHeader);
+      log.info("Given token -> {}", token);
+      // 잘 불러와진다면 여기서 사용자 인증 추가
+    }
+    return true;
+  }
+
+  @Override
+  public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+
+  }
+}

--- a/common-module/src/main/java/com/yapp/crew/auth/Auth.java
+++ b/common-module/src/main/java/com/yapp/crew/auth/Auth.java
@@ -1,0 +1,43 @@
+package com.yapp.crew.auth;
+
+import com.yapp.crew.domain.errors.TokenRequiredException;
+import com.yapp.crew.domain.errors.WrongTokenPrefixException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class Auth {
+
+  @Value(value = "${jwt.secret}")
+  private String jwtSecret;
+
+  @Value(value = "${jwt.prefix}")
+  private String jwtPrefix;
+
+  public void verifyToken(String token) throws TokenRequiredException, WrongTokenPrefixException {
+    if (token == null || token.isBlank()) {
+      throw new TokenRequiredException("[Chatting Service - Handshake] Token is required but wasn't sent");
+    }
+
+    if (!token.startsWith("Bearer")) {
+      throw new WrongTokenPrefixException("[Chatting Service - Handshake] Bearer is required for token prefix");
+    }
+  }
+
+  public Long parseUserIdFromToken(String token) {
+    token = token.replace(jwtPrefix + " ", "");
+    Jws<Claims> claimsJws = Jwts.parserBuilder()
+        .setSigningKey(Keys.hmacShaKeyFor(jwtSecret.getBytes()))
+        .build()
+        .parseClaimsJws(token);
+
+    Claims body = claimsJws.getBody();
+    return Long.parseLong(String.valueOf(body.get("userId")));
+  }
+}

--- a/common-module/src/main/java/com/yapp/crew/domain/errors/TokenRequiredException.java
+++ b/common-module/src/main/java/com/yapp/crew/domain/errors/TokenRequiredException.java
@@ -1,0 +1,8 @@
+package com.yapp.crew.domain.errors;
+
+public class TokenRequiredException extends RuntimeException {
+
+  public TokenRequiredException(String message) {
+    super(message);
+  }
+}

--- a/common-module/src/main/java/com/yapp/crew/network/handler/CommonExceptionHandler.java
+++ b/common-module/src/main/java/com/yapp/crew/network/handler/CommonExceptionHandler.java
@@ -23,11 +23,13 @@ import com.yapp.crew.domain.errors.NoSpaceToApplyException;
 import com.yapp.crew.domain.errors.ReportCodeNotFoundException;
 import com.yapp.crew.domain.errors.SuspendedUserException;
 import com.yapp.crew.domain.errors.TagNotFoundException;
+import com.yapp.crew.domain.errors.TokenRequiredException;
 import com.yapp.crew.domain.errors.UnAuthorizedEventException;
 import com.yapp.crew.domain.errors.UserDuplicateFieldException;
 import com.yapp.crew.domain.errors.UserNotFoundException;
 import com.yapp.crew.domain.errors.WrongGuestException;
 import com.yapp.crew.domain.errors.WrongHostException;
+import com.yapp.crew.domain.errors.WrongTokenPrefixException;
 import com.yapp.crew.domain.type.ResponseType;
 import com.yapp.crew.network.model.SimpleResponse;
 import java.sql.SQLException;
@@ -296,6 +298,20 @@ public class CommonExceptionHandler {
 	public ResponseEntity<?> handleReportCodeNotFoundException(ReportCodeNotFoundException ex) {
 		log.error(ex.getMessage());
 		SimpleResponse responseBody = SimpleResponse.fail(HttpStatus.NOT_FOUND, ResponseType.REPORT_CODE_NOT_FOUND);
+		return ResponseEntity.ok().body(responseBody);
+	}
+
+	@ExceptionHandler(value = WrongTokenPrefixException.class)
+	public ResponseEntity<?> handleWrongTokenPrefixException(WrongTokenPrefixException ex) {
+		log.error(ex.getMessage());
+		SimpleResponse responseBody = SimpleResponse.fail(HttpStatus.FORBIDDEN, ResponseType.AUTHORIZATION_HEADER_REQUIRED);
+		return ResponseEntity.ok().body(responseBody);
+	}
+
+	@ExceptionHandler(value = TokenRequiredException.class)
+	public ResponseEntity<?> handleTokenRequiredException(TokenRequiredException ex) {
+		log.error(ex.getMessage());
+		SimpleResponse responseBody = SimpleResponse.fail(HttpStatus.FORBIDDEN, ResponseType.TOKEN_REQUIRED);
 		return ResponseEntity.ok().body(responseBody);
 	}
 }


### PR DESCRIPTION
## 변경 사항

- 웹소켓 프로토콜로 클라이언트와 연결 하기 전에 Handshake를 시도합니다
  - Handshake는 http 프로토콜에서 websocket 프로토콜로 업그레이드를 할 수 있도록 http 요청을 한번 보내는 겁니다.(응답 코드: 101)

- 기존에는 메시지를 보낼때 마다 사용자 인증을 하려고 했지만, 첫 웹소켓 연결시 한번만 handshake를 진행하고 웹소켓 연결이 끊어질때까지 연결을 유지하기 때문에 차라리 handshake 과정에서 사용자인증을 하는게 더 나을것 같다고 판단.