### PR TITLE
fix: add kafka log retention time options

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,6 +14,8 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: 101.101.219.23
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LOG_RETENTION_MS: 10000
+      KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS: 5000
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: 52.78.52.254
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LOG_RETENTION_MS: 10000
+      KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS: 5000
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:


### PR DESCRIPTION
## 변경 사항

- 제가 알기로는 디폴트 메시지 저장 시간이 7일인걸로 알고 있습니다
- ```KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS: 5000```
  - 5초 마다 10초보다 오래된(```KAFKA_LOG_RETENTION_MS: 10000```) 메시지를 삭제